### PR TITLE
Fix requirements.txt syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pip install numpy
-pip install scipy
+numpy
+scipy


### PR DESCRIPTION
The requirements.txt file currently includes `pip install` ahead of each package name which is incorrect syntax. Only the package name (and version) should be listed.